### PR TITLE
Add optional configuration file /etc/mediamon/mediamon.ini

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,19 @@ Usage
    that it's working. You should see a ``synoindex -a`` entry for each added
    file.
 
+Note: To change the default watched folders, you can add
+/etc/mediamon/mediamon.ini (adapt to your needs):
+
+[main]
+
+# logging file
+logfile = /var/log/mediamon.log
+# pid file
+pidfile = /var/run/mediamon.pid
+# list of space separated paths to watch
+watched_paths = /volume1/video /volume1/tech-conf /volume1/foobar
+# list of space separated allowed extensions
+allowed_exts = jpg jpeg png tga gif bmp ogg ogv mp4 avi m4v
 
 Caveats
 -------

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,8 @@ MediaMon
 
 File monitor and auto-indexer for Synology DiskStation NAS.
 
-I'm using this on a DS213j, but I expect it may work on other models as well.
+I'm using this on a DS213j, but I expect it may work on other models
+as well (DS214+ was reported successfully for one).
 
 
 Usage

--- a/mediamon.py
+++ b/mediamon.py
@@ -10,24 +10,49 @@ import sys
 from datetime import datetime
 from subprocess import call
 
-conf_file = '/etc/mediamon/mediamon.ini'
-config_path = os.path.expanduser(conf_file)
+CONFIG_PATH = '/etc/mediamon/mediamon.ini'
 
-if os.path.exists(config_path):
-    confparser = ConfigParser.ConfigParser()
-    confparser.read(config_path)
-    config = confparser._sections['main']
-else:  # default one based on original code
-    config = {
-        'logfile': '/var/log/mediamon.log',
-        'pidfile': '/var/run/mediamon.pid',
-        'watched_paths': '/volume1/music /volume1/photo /volume1/video',
-        'allowed_exts': 'jpg jpeg png tga gif bmp mp3 flac aac wma ogg ogv '
-                        'mp4 avi m4v'
-    }
+CONFIG_DEFAULT = {
+    'logfile': '/var/log/mediamon.log',
+    'pidfile': '/var/run/mediamon.pid',
+    'watched_paths': '/volume1/music /volume1/photo /volume1/video',
+    'allowed_exts': 'jpg jpeg png tga gif bmp mp3 flac aac wma ogg ogv '
+                    'mp4 avi m4v'
+}
 
-watched_paths = config['watched_paths'].split(' ')
-allowed_exts = set(config['allowed_exts'].split(' '))
+def read_configuration(config_path=None):
+    # read from file or set the default configuration file
+    if config_path and os.path.exists(config_path):
+        # Expects an optional config_path configuration file of the form:
+        # [main]
+        #
+        # logging file
+        # logfile = /var/log/mediamon.log
+        #
+        # pid file
+        # pidfile = /var/run/mediamon.pid
+        #
+        # list of space separated paths to watch
+        # watched_paths = /volume1/techconf /volume1/musics /volume1/pix
+        #
+        # list of space separated allowed extensions
+        # allowed_exts = jpg png gif bmp mp3 flac aac wma ogg ogv mp4 avi m4v
+
+        confparser = ConfigParser.ConfigParser()
+        confparser.read(config_path)
+        config = confparser._sections['main']
+    else:  # default one based on original code
+        config = CONFIG_DEFAULT
+
+    config['watched_paths'] = config['watched_paths'].split(' ')
+    config['allowed_exts'] = set(config['allowed_exts'].split(' '))
+
+    return config
+
+config = read_configuration(CONFIG_PATH)
+
+watched_paths = config['watched_paths']
+allowed_exts = config['allowed_exts']
 
 log_file = open(config['logfile'], "a")
 

--- a/mediamon.py
+++ b/mediamon.py
@@ -13,7 +13,7 @@ log_file = open("/var/log/mediamon.log", "a")
 
 def log(text):
     dt = datetime.utcnow().isoformat()
-    log_file.write(dt + ' - ' + text + "\n")
+    log_file.write(''.join([dt, ' - ', text, '\n']))
     log_file.flush()
 
 

--- a/mediamon.py
+++ b/mediamon.py
@@ -94,7 +94,7 @@ class EventHandler(pyinotify.ProcessEvent):
             self.modified_files.add(event.pathname)
 
     def process_IN_CLOSE_WRITE(self, event):
-        # ignore close_write unlesss the file has previously been modified.
+        # ignore close_write unless the file has previously been modified.
         if (event.pathname in self.modified_files):
             self.do_index_command(event, "-a")
 

--- a/mediamon.py
+++ b/mediamon.py
@@ -113,9 +113,7 @@ class EventHandler(pyinotify.ProcessEvent):
             ext = os.path.splitext(filename)[1][1:].lower()
             if ext not in allowed_exts:
                 return False
-        if filename.find("@eaDir") > 0:
-            return False
-        return True
+        return not (filename.find("@eaDir") > 0)
 
 handler = EventHandler()
 notifier = pyinotify.Notifier(wm, handler)


### PR DESCRIPTION
Hello,

I've a slightly different volumes repartition.

The idea is to have an /etc/mediamon/mediamon.ini file:

        [main]
        
        # logging file
        logfile = /var/log/mediamon.log
        
        # pid file
        pidfile = /var/run/mediamon.pid
        
        # list of space separated paths to watch
        watched_paths = /volume1/techconf /volume1/musics /volume1/pix
        
        # list of space separated allowed extensions
        allowed_exts = jpg png gif bmp mp3 flac aac wma ogg ogv mp4 avi m4v

Also, if this file is not provided, it keeps working with the original defaults.